### PR TITLE
Read me setup guide update (wallet version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![Trittium Coin](http://54.36.159.72:8080/images/logo.png)
 
-Use this instructions to install the wallet,  and setup single masternode on Windows machine(HOT walet)(s).
+Use this instructions to install the wallet,  and setup single masternode on Windows machine (HOT wallet/s).
 
 
 ## Table of Content
@@ -16,69 +16,99 @@ Use this instructions to install the wallet,  and setup single masternode on Win
 ## 1. Desktop Wallet Preparation
 
 ### 1.1 Setup the wallet
-1. Download the [wallet](https://github.com/Trittium/Trittium-wallets/raw/master/trittium-qt-windows-2.0.0-release.zip)
-1. Start the wallet and wait for the sync. (30min to 10h depending on the number of the connections)
+a. Download the [wallet](https://github.com/Trittium/trittium/releases/download/2.1.1/Trittium-2.1.1-Windows-QT.zip)
+b. Start the wallet and wait for the sync. (30min to 10h depending on the number of the connections)
 	
 ## 2. Masternode Setup
 
-### 2.1 Send the coins to your wallet
-1. Open Console (Tools => Debug console)
-1. Create a new address. `getnewaddress MN1`
-1. Send exactly 50000 coins to this address. (One transaction, pay attention to the fee)
-1. Wait for the 1 confirmation.
-1. Generate a new masternode private key `masternode genkey`.
-1. Take txID of collateral transaction  `masternode outputs`. 
-1. Do not close console, or copy results to any place.
+### 2.1 Send the coins to your wallet. Open Console (Tools => Debug console)
+a. Create a new address. `getnewaddress MN1`
+b. Send exactly 50000.00 coins to the generated address. (Send all coins in one transaction, fees should be paid additionally on top on 50k amount)
+c. Wait for the at least 1 confirmation of the transaction.
+d. Generate a new masternode private key by running the following command in wallet debug console `masternode genkey`.
+e. Take txID of collateral transaction by running the following command in wallet debug console `masternode outputs`. 
+f. Do not close console, or copy results to any place.
 
 ### 2.2 VPS setup
-1. Register on [Aruba] https://www.arubacloud.com/vps/virtual-private-server-range.aspx and setup small VPS server (for 1 eur/month).
-Also you can use [Vultr](https://www.vultr.com) or [DigitalOcean](https://digitalocean.com) (do not forget verify your e-mail)
-1. Send some money to your account to deploy a server. 
-1.  - Server Type: Ubuntu 16.04
-    - Server Size: 1GB memory (This server is capable to run 3 masternodes. One masternode need 150-300Mb memory)
+a. Register on [Aruba] https://www.arubacloud.com/vps/virtual-private-server-range.aspx and setup small VPS server (for 1 eur/month).
+
+OR
+
+Also you can use [Vultr](https://www.vultr.com) 
+
+OR
+
+[DigitalOcean](https://digitalocean.com) (do not forget verify your e-mail)
+
+b. Send some money to your account to deploy a server. 
+c. Recommended server configuration:  
+- OS: Ubuntu 16.04
+- Memory: 1GB (This server is capable to run 3 masternodes. One masternode need 150-300Mb memory)
+- Storage: 10GB minimum free space
 
 ### 2.3 Automatic Masternode Setup
-1. Download [putty](https://the.earth.li/~sgtatham/putty/latest/w64/putty-64bit-0.70-installer.msi)
-1. Start putty and login as root user. (Root password and server ip address is in VPS overview tab)
-1. Paste this command and answer the questions:
+a. Download [putty](https://the.earth.li/~sgtatham/putty/latest/w64/putty-64bit-0.70-installer.msi)
+b. Start putty and login as root user. (Root password and server ip address are on your VPS management page)
+c. Recommended to run following command before starting the installation script `apt-get update && apt-get upgrade`
+d. To start the installation, paste this command and answer the questions:
 ```
 bash <( curl https://raw.githubusercontent.com/Trittium/MNSetUp-scrypt-NEW/master/install.sh )
 
 ```
-4.  After script finished , copy "string for masternode.conf".
+e.  After script finished , copy "string for masternode.conf".
 
 ### 2.4 Add masternode on the desktop wallet
 
-1. Go to Trittium base folder
-1. Open 'masternode.conf' file to edit.
-1. Add new string from "string for masternode.conf"
-   It will look like 
-   MN1 IP:30001 masternodeprivkey [25k desposit transaction id. 'masternode outputs'] [25k desposit transaction index. 'masternode outputs']
-   Past your transaction id. and transaction index from step 2.1. For example 629dc27b721f57c97550868cac9f7e41049d12cce8ac344732b7f74a9fc81815  0.  
-   Save file. Restart wallet. You must wait 15 confirmations of collateral transaction. Then go to tab Masternodes and push 'Start missing' button.
+a. Go to Trittium base folder (`C:\Users\[your account folder]\AppData\Roaming\Trittium2` for Windows 7 desctops)
+b. Open 'masternode.conf' file in text editor (note pad for example for Windows users).
+c. Add new line and paste the string copied from "string for masternode.conf" (output of installation script run on VPS)
+   
+  It will look like: 
+  MN1 IP:30001 masternodeprivkey [50K desposit transaction id. 'masternode outputs'] [50K desposit transaction index. 'masternode outputs']
+   
+  For example: 
+  `MN1 192.168.1.1:30001 93HaYBVUCYjEMeeH1Y4sBGLALQZE1Yc1K64xiqgX37tGBDQL8Xg 2bcd3c84c84f87eaa86e4e56834c92927a07f9e18718810b92e0d0324456a67c 0`
+
+  Label: `MN1`
+  IP Address and port: `192.168.1.1:30001`
+  Private key: `93HaYBVUCYjEMeeH1Y4sBGLALQZE1Yc1K64xiqgX37tGBDQL8Xg`
+  Transaction ID: `629dc27b721f57c97550868cac9f7e41049d12cce8ac344732b7f74a9fc81815`
+  Output index:  `0`
+
+  You can also create it yourself by Copying your masternode private key, transaction id and transaction index from step 2.1.d and 2.1.e
+
+d. Save file (masternode.conf)
+e. Restart wallet.
+f. You must wait 15 confirmations of collateral transaction (50000.00 TRTT)
+g. Go to tab Masternodes in your wallet and press 'Start missing' button.
 
 
-Congratulation!!
-Your MN started!!   
+Congratulations!!
+Your MN is now started!!   
 	
 
 ## 3. FAQ
 
 
-1. How to get masternode profit?
-	- Enable coin controll feature (Settings => Options => Display => Display coin controll feature)
-	- Go send tab
-	- Select from the input button only the 5 coin lines
-	- Click OK
-	- You can send selected amount to an address.
-	- Note: DO NOT EVER Transfer TRTT from that original 50k deposit or you'll break your Masternode.
-1. What is the password for the tritt account on VPS?
+1. How can I get my masternode rewards transfered to other address?
+	1.1 Enable coin control feature in your wallet (Settings => Options => Display => Display coin control feature)
+	1.2 Go to send tab
+        1.3 Press the button `Open Coin Control`
+	1.4 Select from the input list button only the inputs with amounts different of MN collateral (50000.00)
+	1.5 Click OK
+	1.6 You can send selected amount to any valid TRTT address.
+	1.7 Note: DO NOT EVER Transfer TRTT from that original 50k deposit or you'll break your Masternode.
+
+2. What is the password for the tritt account on VPS?
 	- There is no default password. When you create a user it does not have a password.
-1. I get the following error: "Could not allocate vin"
+
+3. I get the following error: "Could not allocate vin".
 	- Make sure your wallet fully synced and UNLOCKED.
-1. How many masternodes can I run using one IP/server?
-	- The limit is only the memory. One masternode requires 150-300MB ram. A server with 1GB memory can run 3 masternodes. But only one Trittium MN can work with one public IP.
-1. I got stuck. Can you help me?
-	- Try to get help from the cummunity
+
+4. How many masternodes can I run using one IP/server?
+	- The limit is only the memory. One masternode requires 150-300MB RAM. A server with 1GB memory can run 3 masternodes. Each Trittium MN requires own public IP, so you will need additional IP address(es) to run multiple TRTT MNs on same server.
+
+5. I got stuck. Can you help me?
+	- Try to get help from the community and remember to get help only in public channels. Look for our moderators first!
 		- [Trittium-team Discord](https://discord.gg/DXQbQ9)
 		- [https://bitcointalk.org/index.php?topic=3397622.0 ](https://bitcointalk.org/index.php?topic=3397622.0 )


### PR DESCRIPTION
The update main reason was to update the mismatch in guide and install script.
Link for 2.0.0 wallet version was provided in setup guide (README file).
Some corrections done in order to make the guide more friendly.